### PR TITLE
Copy update + rearrange H1

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -258,11 +258,15 @@ textarea {
   position: sticky;
   position: -webkit-sticky;
   left: 0;
-  z-index: 20; }
+  z-index: 20;
+  margin-top: 32px; }
   @media only screen and (min-width: 600px) {
     .type-xlg {
       font-size: 30px;
       line-height: 1.4; } }
+  @media only screen and (min-width: 1137px) {
+    .type-xlg {
+      margin-top: 40px; } }
 
 .type-lg {
   color: #243137;
@@ -309,9 +313,6 @@ textarea {
   position: -webkit-sticky;
   position: sticky;
   left: 0; }
-
-.old-price {
-  margin-top: 0; }
 
 .new-price {
   margin-bottom: 8px; }

--- a/index.html
+++ b/index.html
@@ -8,53 +8,47 @@
 </head>
 
 <body>
+	<h1 class="type-xlg type-center">Exclusive GoSwim plans for ASCA members</h1>
 	<div class="fade"></div>
 	<div class="wrapper">
-	<h1 class="type-xlg type-center">Exclusive plans for ASCA members</h1>
 	<div class="grid-container">
 	<div class="grid-item grid-row grid-label">
-		<p class="type-md label">GoSwim Annual Plans</p>
+		<p class="type-md label">ASCA GoSwim Annual Plans</p>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Member</p>
 		<span class="badge badge-pro">Pro</span>
 		<p class="type-lg new-price">$61.99</p>
-		<p class="type-sm old-price">Was $149.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Silver</p>
 		<span class="badge badge-pro">Pro</span>
 		<p class="type-lg new-price">$111.99</p>
-		<p class="type-sm old-price">Was $199.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Gold</p>
 		<span class="badge badge-pro">Pro</span>
 		<p class="type-lg new-price">$211.99</p>
-		<p class="type-sm old-price">Was $299.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Member</p>
 		<span class="badge badge-coach">Coach</span>
 		<p class="type-lg new-price">$111.99</p>
-		<p class="type-sm old-price">Was $199.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Silver</p>
 		<span class="badge badge-coach">Coach</span>
 		<p class="type-lg new-price">$161.99</p>
-		<p class="type-sm old-price">Was $249.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<div class="grid-item">
 		<p class="type-md">Gold</p>
 		<span class="badge badge-coach">Coach</span>
 		<p class="type-lg new-price">$261.99</p>
-		<p class="type-sm old-price">Was $349.99</p>
 		<a class="button" href="">Buy Now</a>
 	</div>
 	<!--ASCA Group Row -->

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -14,9 +14,13 @@
   position: -webkit-sticky;
   left: 0;
   z-index: $z-2;
+  margin-top: $unit-lg;
   @media only screen and (min-width: $bp-sm) { 
     font-size: $type-size-xlg;
     line-height: 1.4;
+  }
+  @media only screen and (min-width: 1137px) { 
+    margin-top: $unit-xlg;
   }
 }
 
@@ -70,9 +74,6 @@
   left: 0;
 }
 
-.old-price {
-  margin-top: 0;
-}
 .new-price {
   margin-bottom: $unit-xsm;
   


### PR DESCRIPTION
### Purpose:
- Remove "was" price
- Add new content to title and labels
- Move H1 out of div so it doesn't collide with `.fade`

### Screenshot:
<img width="512" alt="screen shot 2018-08-23 at 6 52 45 pm" src="https://user-images.githubusercontent.com/4184008/44560710-e4cb3d80-a705-11e8-9537-46f42c1de436.png">
